### PR TITLE
fix: replace all dashes in transform

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export function transform(
 
   variables.forEach(variable => {
     let value;
-    const name = path.parse(variable.name).base.replace('-', '_');
+    const name = path.parse(variable.name).base.replace(/-/g, '_');
     debug(opts, `Found: ${name}`);
 
     if (opts.only!.length && opts.only!.indexOf(name) === -1) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -45,7 +45,26 @@ describe('rcloadenv api', () => {
   }) as typeof rcloadenv;
 
   it('should transform variables', () => {
-    assert.ok(rc.transform);
+    assert.deepStrictEqual(
+      rc.transform([
+        {
+          name: 'projects/my-project/configs/my-config/variables/foo-bar',
+          value: Buffer.from('foobar').toString('base64'),
+          updateTime: '2021-04-02T18:54:21.123157030Z',
+        },
+        {
+          name: 'projects/my-project/configs/my-config/variables/foo-bar-baz',
+          value: Buffer.from('foobarbaz').toString('base64'),
+          updateTime: '2021-04-02T18:54:19.748781825Z',
+        },
+      ]),
+      {
+        foo_bar: 'foobar',
+        FOO_BAR: 'foobar',
+        foo_bar_baz: 'foobarbaz',
+        FOO_BAR_BAZ: 'foobarbaz',
+      }
+    );
   });
 
   it('should load variables', async () => {


### PR DESCRIPTION
Or would the better behaviour be to leave the original/lowercase version with dashes and only switch to underscores in the upper-case version? That would mean we can remove the `.replace` entirely and just let lodash snakecase handle it for the uppercase version.
If the (almost) original lowercase version is also included in the result object, wouldn't users expect the original version there?

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue : https://github.com/googleapis/nodejs-rcloadenv/issues/228
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary): **not needed**

Fixes #228
